### PR TITLE
Clarify issue workflow, add Sprints doc

### DIFF
--- a/team/Issue-Management.md
+++ b/team/Issue-Management.md
@@ -3,24 +3,42 @@ Issues are filed in GitHub to the corresponding and related repository. We use [
 
 We are following the process described here: https://www.zenhub.io/blog/how-the-zenhub-team-uses-zenhub-boards-on-github/ This document will only cover differences, clarifications or modifications that are specific to PRX.
 
-### Issue Pipelines
+# Pipelines
 We use the same pipelines as ZenHub:
 * New Issues --> Ice Box | Backlog <--> In Progress <--> Review/QA --> Done --> Closed
 
-### How do I create a New Issue?
+# How do I create a New Issue?
 Go to the appropriate repository and select "New Issue". Provide a meaningful title and enough of a description to help people review and understand the issue for triage. The most helpful part of the description is any acceptance criteria for the issue. For example:
 
 > We'll know this issue is done when
 >  * [ ] the URL https://foobar.prx.org/ returns a 200 response
 >  * [ ] the content of the response includes `hello world`
 
-When New Issues are created they are typically un-assigned, unless you are creating the issue specifically to track your own task. Do not assign to an Epic (Sprint), unless it is the current Epic (Sprint) and you are assigning the issue to yourself. Do not assign an Estimate or Priority label unless you are confident in those values.
+A new issue should default to the `New Issues` Pipeline. The following metadata are also available.
 
-### Grooming
+## Assignee
 
-The goal of the grooming exercise is to move issues from the New Issues column to the **Backlog**. In order to be in the **Backlog**, an issue should have an *Estimate* and a *Priority*. Sometimes issues just aren't clear enough, are an idea that we don't want to lose or aren't yet high enough priority to move into the **Backlog**. We use the **Ice Box** as a place to hold onto those issues.
+When `New Issues` are created they are typically un-assigned, unless you are creating the issue specifically to track your own task.
 
-#### Estimate
+## Milestone
+
+Do not assign to a **Milestone** ([Sprint](Sprints.md)), unless you are assigning the issue to yourself.
+
+## Priority
+
+Feel free to assign a priority label of `low`, `medium` or `high`. Note that the priority may change during grooming.
+
+## Estimate
+
+ZenHub offers the Estimate field that vanilla GitHub does not. Feel free to assign an Estimate if you feel confident about the level of effort required to accomplish the issue. An Estimate must be set before the issue is moved to the `Backlog` Pipeline.
+
+# Grooming
+
+The goal of the grooming exercise is to move issues from the `New Issues` Pipeline to the `Backlog`. In order to be in the `Backlog`, an issue should have an **Estimate** and a **Priority**.
+
+Sometimes issues just aren't clear enough in their description, or are an idea that we don't want to lose, or aren't yet high enough priority to move into the `Backlog`. We use the `Ice Box` as a place to hold onto those issues.
+
+## Estimate
 We use T-shirt sizes to gauge the level of effort estimated for an issue. ZenHub uses numbers, so we mentally map them like this:
 ```
 1: Extra small
@@ -30,28 +48,20 @@ We use T-shirt sizes to gauge the level of effort estimated for an issue. ZenHub
 8: Extra large
 ```
 
-#### Priority
-We use labels to assign a Priority of "high", "medium" or "low". The Priority should reflect both business and technical need for a particular issue. In theory, all "high" issues should receive attention before "medium" issues, etc.
+## Priority
+We use labels to assign a Priority of `high`, `medium` or `low`. The Priority should reflect both business and technical need for a particular issue. In theory, all `high` issues should receive attention before `medium` issues, etc.
 
-### Need input or review on an issue?
-Issues that might require more information should have the label "reviewplx" added to them. We use @mentions to draw the attention of people to the issue. 
+# Need input or review on an issue?
+Issues that might require more information should have the label `reviewplx` added to them. We use @mentions to draw the attention of people to the issue.
 
-### What does it mean for an issue to be in the Done pipeline?
-The issue has been completed, but is not yet in production
+# What does it mean for an issue to be in the Done pipeline?
+The issue has been completed, but is not yet deployed to production.
 
-### Closed issues
-Once a done issue has been deployed, it can be marked as Closed.
+# Closed issues
+Once a `Done` issue has been deployed, it can be closed.
 
-### How do I know if a ticket has been deployed?
+# How do I know if a ticket has been deployed?
 Deployment notifications are sent as messages to the #ops-deploys Slack channel with the date and time of deployment. 
 
-### How are issues assigned?
+# How are issues assigned?
 Tickets are assigned during Sprint Planning, but may be adjusted later.
-
-## Issue Labels
-### Milestone Goal
-Used to identify the issue that provides a high level overview for a milestone.
-### reviewplx
-Waiting on input from the current assignee. If you need someone to review 
-### estimateplx
-Issues with this label are needing an effort estimate from the current assignee.

--- a/team/Sprints.md
+++ b/team/Sprints.md
@@ -1,0 +1,24 @@
+Sprints
+=======
+
+# Overview
+
+Although [tickets are managed](Issue-Management.md) using a [Kanban](http://kanbanblog.com/explained/) process, we organize our time into cycles using the [Scrum](https://www.scrumalliance.org/why-scrum) framework. Each cycle is a specific period of time (a Sprint) during which we focus on a particular set of groomed issues. We bookend the Sprint with ceremonies in order to provide a regular rhythm of planning and reflection.
+
+# Planning
+
+The Sprint begins with planning which issues will be addressed and by whom. To be included in a Sprint, an issue must have a **Priority** and an **Estimate**.
+
+Prior to the Planning meeting, team members identify those issues from the `Backlog` which they believe can and should be completed during the Sprint, and assigns each issue to themselves as the **Assignee** and to the **Milestone** specific to the Sprint.
+
+During the Planning meeting, all the issues in the Sprint **Milestone** are briefly reviewed, verifying with the **Assignee** that the **Estimate** and **Priority** are correct.
+
+The goal of the Planning meeting is to align the team's expectations about the Sprint to come. We know we were accurate in our planning if during the Review meeting there are zero issues that are incomplete.
+
+# Review
+
+The Sprint ends with a review of the **Milestone** issues and any relevant demonstrations of work accomplished. If an issue is not in the `Done` or `Closed` **Pipeline** we try and determine why, and whether it should be moved to the next **Milestone** or put back into the general `Backlog`. We [avoid blame](https://codeascraft.com/2012/05/22/blameless-postmortems/) and [apologies](http://retrospectives.com/pages/retroPrimeDirective.html), and instead focus on surfacing those events that helped or hurt our ability to accomplish what we thought we could. This meeting is fairly short (less than 30 minutes).
+
+# Retrospective
+
+The Review meeting focuses on the "what" of the Sprint. The Retrospective meeting focuses on the "how" of the Sprint. We ask ourselves what went well, what did not, and what actions we should take to adjust our practices for next time. This meeting can take up to an hour.


### PR DESCRIPTION
* Adds some Markdown syntax fixups
* Adds clarity around creating a new issue
* Documents our Sprint rituals